### PR TITLE
update the date format as reflected on the web source

### DIFF
--- a/healthtools/scrapers/clinical_officers.py
+++ b/healthtools/scrapers/clinical_officers.py
@@ -26,9 +26,9 @@ class ClinicalOfficersScraper(Scraper):
         :return: dictionaries of the entry's metadata and the formatted entry
         """
         try:
-            date_obj = datetime.strptime(entry["reg_date"], "%Y-%m-%d")
+            date_obj = datetime.strptime(entry["reg_date"], "%Y-%m-%d %H:%M")
         except:
-            date_obj = datetime.strptime(entry["reg_date"], "%d-%m-%Y")
+            date_obj = datetime.strptime(entry["reg_date"], "%d-%m-%Y %H:%M")
         entry["reg_date"] = datetime.strftime(
             date_obj, "%Y-%m-%dT%H:%M:%S.000Z")
         # all bulk data need meta data describing the data


### PR DESCRIPTION
The date format for the column 'Reg date' on the web source for clinical officers was been changed.
The change caused runtime error when scraping data for clinical officer
This Pull Request updates the date format to match the format excepted from the web source. 